### PR TITLE
Add `AtomicBitSet::capacity`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -824,6 +824,20 @@ impl AtomicBitSet {
         }
     }
 
+    /// Get the current capacity of the bitset.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uniset::AtomicBitSet;
+    ///
+    /// let set = AtomicBitSet::new();
+    /// assert_eq!(0, set.capacity());
+    /// ```
+    pub fn capacity(&self) -> usize {
+        self.cap
+    }
+
     /// Set the given bit atomically.
     ///
     /// We can do this to an [AtomicBitSet] since the required modifications


### PR DESCRIPTION
Hey! I've been trying to use your crate here and I ran into a usecase where I needed to know the capacity of the bitset. I didn't see any reason that this shouldn't be exposed so I figured I might as well just send in a PR.

The new method is a straight copy of the same method from `BitSet::capacity`.